### PR TITLE
Make linkcheck pass

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -58,6 +58,10 @@ hoverxref_mathjax = True
 mathjax_path = 'https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js'
 
 # Disable following anchors in URLS for linkcheck
+linkcheck_ignore = [
+    r".*andymark.com.*"
+]
+
 linkcheck_anchors = False
 
 # Configure linkcheck

--- a/source/docs/robot-design/power-transmission/chain.rst
+++ b/source/docs/robot-design/power-transmission/chain.rst
@@ -36,7 +36,7 @@ Roller Chain
 Center-to-Center calculations
 -----------------------------
 
-The equation to calculate :term:`center-to-center <C2C>` for chain is quite complicated. Many `online calculators <http://www.botlanta.org/converters/dale-calc/sprocket.html>`_ can calculate C-C distances without going through the tedious calculations. However, the complete formula is below.
+The equation to calculate :term:`center-to-center <C2C>` for chain is quite complicated. Many `online calculators <https://reca.lc/chains>`_ can calculate C-C distances without going through the tedious calculations. However, the complete formula is below.
 
 .. math::
 

--- a/source/docs/useful-resources.rst
+++ b/source/docs/useful-resources.rst
@@ -131,8 +131,6 @@ Calculators
 
 `⎰ReCalc <https://reca.lc/>`_ --- A collaboration focused mechanical design calculator, currently in alpha, which provides sharable links.
 
-`Sprocket Center-to-Center Calculator <http://www.botlanta.org/converters/dale-calc/sprocket.html>`_ --- A chain sprocket center-to-center calculator, either using the number of links to calculate center distance or using the center distance to calculate the number of links.
-
 `Thad's EveryCalc <http://everycalc.thadhughes.xyz/>`_ --- A mechanical design calculator which covers a wide variety of mechanisms, while also providing some utilities like belt sizing, a trajectory calculator, and more.
 
 Programming


### PR DESCRIPTION
AndyMark links are marked as broken in linkcheck, even if they work.
Botlanta's chain calculator is now inaccessible.