### PR TITLE
Add Canva to the linkcheck ignore list

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -60,7 +60,8 @@ mathjax_path = 'https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js'
 
 # Disable following anchors in URLS for linkcheck
 linkcheck_ignore = [
-    r".*andymark.com.*"
+    r".*andymark.com.*",
+    r".*canva.com.*"
 ]
 
 linkcheck_anchors = False


### PR DESCRIPTION
Canva links fail linkcheck, even when they work, they are likely blocking the requests server-side.