### PR TITLE
Improve windows build compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,10 @@ LINTER = doc8
 LINTEROPTS = --ignore D001,WUMBO007,WUMBO008
 #D001 is linelength, WUMBO007/008 are trademark and italicization respectively
 
+WINDOWSLINTEROPTS = --ignore D001,D004,WUMBO007,WUMBO008
+# D004 is CRLF line endings;
+# git on windows often uses these but only in the working tree.
+
 AUTOBUILD = sphinx-autobuild
 HTMLBUILDDIR = build/html
 
@@ -22,6 +26,9 @@ help:
 
 lint:
 	@$(LINTER) $(LINTEROPTS) $(SOURCEDIR)/docs
+
+winlint:
+	@$(LINTER) $(WINDOWSLINTEROPTS) $(SOURCEDIR)/docs
 
 .PHONY: help lint Makefile
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Building
 --------
 
 How to check if the documentation is valid:
-* `make lint`
+* `make lint` (note: on Windows, `make winlint` will ignore CRLF line ending errors)
 * `make linkcheck`
 
 How to build the different versions of the documentation:

--- a/make.bat
+++ b/make.bat
@@ -2,7 +2,7 @@
 
 pushd %~dp0
 
-set SPHINXOPTS=""
+set SPHINXOPTS=
 set SPHINXBUILD=sphinx-build
 set SOURCEDIR=source
 set BUILDDIR=build

--- a/make.bat
+++ b/make.bat
@@ -1,0 +1,46 @@
+@echo off
+
+set SPHINXOPTS=SPHINXBUILD   = sphinx-build
+set SOURCEDIR=source
+set BUILDDIR=build
+set LINTER=doc8
+set LINTEROPTS=--ignore D001,WUMBO007,WUMBO008
+set WINDOWSLINTEROPTS=--ignore D001,D004,WUMBO007,WUMBO008
+set AUTOBUILD=sphinx-autobuild
+set HTMLBUILDDIR=build\html
+
+IF /I "%1"=="help" GOTO help
+IF /I "%1"=="lint" GOTO lint
+IF /I "%1"=="winlint" GOTO winlint
+IF /I "%1"=="autobuild" GOTO autobuild
+IF /I "%1"=="%" GOTO %
+GOTO error
+
+:help
+	@%SPHINXBUILD% -M help "%SOURCEDIR%" "%BUILDDIR%" %SPHINXOPTS% %O%
+	GOTO :EOF
+
+:lint
+	@%LINTER% %LINTEROPTS% %SOURCEDIR%/docs
+	GOTO :EOF
+
+:winlint
+	@%LINTER% %WINDOWSLINTEROPTS% %SOURCEDIR%/docs
+	GOTO :EOF
+
+:autobuild
+	@%AUTOBUILD% %SOURCEDIR% %HTMLBUILDDIR%
+	GOTO :EOF
+
+:%
+	CALL make.bat Makefile
+	@%SPHINXBUILD% -M $@ "%SOURCEDIR%" "%BUILDDIR%" %SPHINXOPTS% %O%
+	GOTO :EOF
+
+:error
+    IF "%1"=="" (
+        ECHO make: *** No targets specified and no makefile found.  Stop.
+    ) ELSE (
+        ECHO make: *** No rule to make target '%1%'. Stop.
+    )
+    GOTO :EOF

--- a/make.bat
+++ b/make.bat
@@ -1,6 +1,7 @@
 @echo off
 
-set SPHINXOPTS=SPHINXBUILD   = sphinx-build
+set SPHINXOPTS=""
+set SPHINXBUILD = sphinx-build
 set SOURCEDIR=source
 set BUILDDIR=build
 set LINTER=doc8

--- a/make.bat
+++ b/make.bat
@@ -1,7 +1,9 @@
 @echo off
 
+pushd %~dp0
+
 set SPHINXOPTS=""
-set SPHINXBUILD = sphinx-build
+set SPHINXBUILD=sphinx-build
 set SOURCEDIR=source
 set BUILDDIR=build
 set LINTER=doc8
@@ -10,38 +12,29 @@ set WINDOWSLINTEROPTS=--ignore D001,D004,WUMBO007,WUMBO008
 set AUTOBUILD=sphinx-autobuild
 set HTMLBUILDDIR=build\html
 
-IF /I "%1"=="help" GOTO help
-IF /I "%1"=="lint" GOTO lint
-IF /I "%1"=="winlint" GOTO winlint
-IF /I "%1"=="autobuild" GOTO autobuild
-IF /I "%1"=="%" GOTO %
-GOTO error
+if "%1" == "help" goto help
+if "%1" == "lint" goto lint
+if "%1" == "winlint" goto winlint
+if "%1" == "autobuild" goto autobuild
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS%
+goto end
 
 :help
 	@%SPHINXBUILD% -M help "%SOURCEDIR%" "%BUILDDIR%" %SPHINXOPTS% %O%
-	GOTO :EOF
+	goto :EOF
 
 :lint
 	@%LINTER% %LINTEROPTS% %SOURCEDIR%/docs
-	GOTO :EOF
+	goto :EOF
 
 :winlint
 	@%LINTER% %WINDOWSLINTEROPTS% %SOURCEDIR%/docs
-	GOTO :EOF
+	goto :EOF
 
 :autobuild
 	@%AUTOBUILD% %SOURCEDIR% %HTMLBUILDDIR%
-	GOTO :EOF
+	goto :EOF
 
-:%
-	CALL make.bat Makefile
-	@%SPHINXBUILD% -M $@ "%SOURCEDIR%" "%BUILDDIR%" %SPHINXOPTS% %O%
-	GOTO :EOF
-
-:error
-    IF "%1"=="" (
-        ECHO make: *** No targets specified and no makefile found.  Stop.
-    ) ELSE (
-        ECHO make: *** No rule to make target '%1%'. Stop.
-    )
-    GOTO :EOF
+:end
+popd

--- a/source/docs/software/index.rst
+++ b/source/docs/software/index.rst
@@ -17,3 +17,4 @@ This section covers the basics of software for FTC.
    vision
    odometry
    control-system-internals
+   control-system-errata

--- a/source/docs/software/index.rst
+++ b/source/docs/software/index.rst
@@ -17,4 +17,3 @@ This section covers the basics of software for FTC.
    vision
    odometry
    control-system-internals
-   control-system-errata


### PR DESCRIPTION
Add a `make.bat` roughly equivalent to the `Makefile` so that Windows users can more easily build the project. Also add a `make winlint` which ignores CRLF line endings as the default git on windows configuration will have CRLF line endings in the working tree but not in the repository itself. 