### PR TITLE
Fix REV Robotics documentation links

### DIFF
--- a/source/docs/common-mechanisms/drivetrains/drivetrain-gallery.rst
+++ b/source/docs/common-mechanisms/drivetrains/drivetrain-gallery.rst
@@ -10,7 +10,7 @@ In this section, we compile several sample drivetrains which you can use as a st
 `Strafer chassis with odometry <https://drive.google.com/file/d/1R85u8nGGmBu5_6jIztOH3-5_W4XK08Mb/view?usp=drive_open>`_
    Modification of goBILDA chassis by FTC 9794 Wizards.exe, which adds :term:`odometry wheels <Odometry wheel>`. Also see their video tutorials:
    https://www.youtube.com/watch?v=OjNvAD350M4&list=PLICNg-rquurYgWAQGhu6iC0At75vgqFJp
-`REV Robotics 6 wheel drivetrain <https://www.revrobotics.com/content/docs/GearDrivetrain-Guide.pdf>`_
+`REV Robotics 6 wheel drivetrain <https://docs.revrobotics.com/duo-build/channel-drivetrain-build-guide>`_
    Sample 6 wheel drivetrain built using REV kit.
 `AndyMark Tile Runner chassis <https://www.andymark.com/products/tilerunner-options>`_
    A universal chassis kit sold by AndyMark. It is available in several modifications: 6 wheel, mecanum, tank tread. It is expensive, but using provided 3d models as inspiration for your own drivetrain is free.

--- a/source/docs/power-and-electronics/control-system.rst
+++ b/source/docs/power-and-electronics/control-system.rst
@@ -10,7 +10,7 @@ The two major manufacturers of control hubs for FTC are Modern Robotics and REV;
 More information about the FTC Control system can be found below:
 
 - `Official control system Wiki on GitHub <https://github.com/FIRST-Tech-Challenge/FtcRobotController/wiki>`_
-- `REV Expansion Hub Documentation <https://docs.revrobotics.com/rev-control-system/control-system-overview/expansion-hub-basics>`_
+- `REV Control System Documentation <https://docs.revrobotics.com/duo-control/>`_
 - `Official troubleshooting guide <https://www.firstinspires.org/sites/default/files/uploads/resource_library/ftc/control-system-troubleshooting-guide.pdf>`_
 
 There are two possible control systems that can be run on an FTC robot legally:
@@ -25,7 +25,7 @@ RC Phone + REV Expansion Hub(s)
 
 This is the standard control system for teams starting out in FTC. The REV Expansion Hub is reliable, as long as proper strain relief and wiring is carried out. This includes the :term:`USB Retention Mount`, as well as 3D printing :term:`XT30` stress relief mounts.
 
-The Expansion Hub connects to the :term:`Robot Controller` phone through the mini USB port, and the :term:`RC <Robot Controller>` phone is linked to the DS (:term:`Driver Station`) phone through WiFi Direct. For more information on setting up the Expansion Hub and configuring the robot, head to `REV Robotics’ Technical Resources Expansion Hub Guide <https://docs.revrobotics.com/rev-control-system/control-system-overview/expansion-hub-basics>`_.
+The Expansion Hub connects to the :term:`Robot Controller` phone through the mini USB port, and the :term:`RC <Robot Controller>` phone is linked to the DS (:term:`Driver Station`) phone through WiFi Direct. For more information on setting up the Expansion Hub and configuring the robot, head to `REV Robotics’ Technical Resources Expansion Hub Guide <https://docs.revrobotics.com/duo-control/legacy/expansion-hub-gs>`_.
 
 - `USB Retention Mount <https://www.revrobotics.com/rev-41-1214/>`_
 - `XT30 Stress Relief <https://www.thingiverse.com/thing:2887045>`_
@@ -46,4 +46,4 @@ Note: The Control Hub will be legal for all teams from the 2020-2021 FTC season 
    :alt: A diagram of the Control Hub + Expansion Hub control system
    :width: 100%
 
-.. _REV Expansion Hub firmware update docs: https://docs.revrobotics.com/rev-control-system/managing-the-control-system/updating-firmware
+.. _REV Expansion Hub firmware update docs: https://docs.revrobotics.com/duo-control/managing-the-control-system/updating-firmware

--- a/source/docs/power-and-electronics/motor-guide/wiring-mounting-motors.rst
+++ b/source/docs/power-and-electronics/motor-guide/wiring-mounting-motors.rst
@@ -29,7 +29,7 @@ If using encoders, you need to connect them to the REV hub by a 4-wire cable. RE
 
 goBILDA motors use JST-XH 4-pin encoder port (**note the difference: XH vs PH**), so to connect them, you need a JST-PH to JST-XH cable, available from AndyMark or goBILDA.
 
-AndyMark also use JST-XH encoder port; however, an additional problem is that encoders of these motors require 5v power, whereas the encoder port of REV hub only provides 3.3v. Thus, it is recommended that you connect them using level shifters, available from REV Robotics. For details please check the `REV Expansion Hub Guide <https://docs.revrobotics.com/rev-control-system/control-system-overview/expansion-hub-basics>`_.
+AndyMark also use JST-XH encoder port; however, an additional problem is that encoders of these motors require 5v power, whereas the encoder port of REV hub only provides 3.3v. Thus, it is recommended that you connect them using level shifters, available from REV Robotics. For details please check the `REV's documentation <https://docs.revrobotics.com/duo-control/sensors/5v-sensors#connecting-5v-encoder>`_.
 
 Mounting Motors
 ---------------

--- a/source/docs/power-and-electronics/sensor-glossary.rst
+++ b/source/docs/power-and-electronics/sensor-glossary.rst
@@ -61,7 +61,7 @@ Other
 Logic Level Converter
 ---------------------
 
-The old Modern Robotics system run on 5v sensor logic. The new REV Robotics system uses 3.3v. For most off the shelf sensors, this doesn’t cause any problems, but for some existing FTC sensors it does. To solve this REV sells boards, called `logic level converters <https://www.revrobotics.com/rev-31-1389/>`_, that convert the sensor data to be readable by the REV hubs. The `REV Expansion Hub <https://docs.revrobotics.com/rev-control-system/control-system-overview/expansion-hub-basics>`_ guide has a chart detailing what adapters are needed for what sensors.
+The old Modern Robotics system run on 5v sensor logic. The new REV Robotics system uses 3.3v. For most off the shelf sensors, this doesn’t cause any problems, but for some existing FTC sensors it does. To solve this REV sells boards, called `logic level converters <https://www.revrobotics.com/rev-31-1389/>`_, that convert the sensor data to be readable by the REV hubs. The `REV Expansion Hub <https://docs.revrobotics.com/duo-control/sensors/5v-sensors#logic-level-converter>`_ guide has a chart detailing what adapters are needed for what sensors.
 
 .. attention:: According to REV testing, goBILDA, REV and TorqueNado motors don’t need logic level converters, but only some NeveRest motors worked with no discernable reason why.
 

--- a/source/docs/power-and-electronics/wiring.rst
+++ b/source/docs/power-and-electronics/wiring.rst
@@ -22,7 +22,7 @@ General Advice
 
 - **Always label wires! When bunched up, you may not know which wire goes into which port**.
 - Tie together loose wires, and better yet, tie that bunch of wires to a structural component. This will ensure that wires don't interfere with your mechanisms.
-- **Pay attention to port numbers!** The rev hub will often have multiple ports per connector on the REV hub. `REV has a pinout guide to avoid confusion <https://docs.revrobotics.com/rev-control-system/control-system-overview/port-pinouts>`_.
+- **Pay attention to port numbers!** The rev hub will often have multiple ports per connector on the REV hub. `REV has a pinout guide to avoid confusion <https://docs.revrobotics.com/duo-control/control-system-overview/port-pinouts>`_.
 - **Treat every wire connection as a point of failure**. Therefore, use electrical tape to tape up and insulate connections and utilize strain relief as much as possible.
 - **Strain relief** should be used everywhere possible. It is highly recommended for teams to use products like the :term:`REV USB Retention Mount <USB Retention Mount>`, as well as 3D printing strain relief methods for devices such as the Expansion Hub and robot controller phones.
 - **DO NOT solder a wire before crimping it**. Solder can "creep" and losing connection is possible, possibly leading to fire.

--- a/source/docs/software/getting-started/using-android-studio.rst
+++ b/source/docs/software/getting-started/using-android-studio.rst
@@ -142,10 +142,10 @@ To install your program onto the Robot Controller, you will use the play button 
 
 Next to it you will see a dropdown for devices. When you connect your Robot Controller to your computer (using the correct cable), the device should appear in the dropdown after some time. Then, click the play button and your program will install onto the device.
 
-If you run into any problems with this process, refer to the official `REV documentation <https://docs.revrobotics.com/rev-control-system/>`_. Some useful pages from the REV site are:
+If you run into any problems with this process, refer to the official `REV documentation <https://docs.revrobotics.com/duo-control/>`_. Some useful pages from the REV site are:
 
 - `Troubleshooting the Control System <https://github.com/FIRST-Tech-Challenge/FtcRobotController/wiki/Android-Studio-Tutorial>`_
-- `Deploying Code Wirelessly <https://docs.revrobotics.com/rev-control-system/programming/android-studio-using-wireless-adb>`_
+- `Deploying Code Wirelessly <https://docs.revrobotics.com/duo-control/programming/android-studio-using-wireless-adb>`_
 
 If you're still stuck you can ask for help in the `FTC Discord <https://discord.com/invite/first-tech-challenge>`_.
 

--- a/source/docs/software/tutorials/control-loops.rst
+++ b/source/docs/software/tutorials/control-loops.rst
@@ -120,7 +120,7 @@ PID can be enabled by changing the run mode to ``RUN_USING_ENCODER``
     Many misunderstand the use of ``RUN_USING_ENCODER``, many may mistake that it is necessary to use this mode for the encoders to work at all, but this is not true. Instead, ``RUN_USING_ENCODER`` enables velocity feedback using the encoder. If you are using an external PID controller such as one that you implement, generally, it is recommended that you use ``RUN_WITHOUT_ENCODER``.
 
 
-For official documentation on the built in PID controller, `see here <https://docs.revrobotics.com/rev-control-system/programming/using-encoder-feedback>`_
+For official documentation on the built in PID controller, `see here <https://docs.revrobotics.com/duo-control/programming/using-encoder-feedback>`_
 
 Debugging Built-In PID Controller
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/docs/useful-resources.rst
+++ b/source/docs/useful-resources.rst
@@ -26,7 +26,7 @@ General Resources
 
 `FIRST Resource Library <https://www.firstinspires.org/resource-library?field_content_type_value%5B%5D=first_tech_challenge>`_  --- FIRST's resource library (filtered for FTC resources). These includes robot/field inspection checklists, robot building and programming resources, team management resources, the FTC mentor manual, and more.
 
-`REV Robotics FTC Documentation <https://docs.revrobotics.com/docs/first-tech-challenge>`_ --- Covers REV's hardware and software. The control system documentation includes an introductory FTC programming tutorial.
+`REV Robotics FTC Documentation <https://docs.revrobotics.com/docs/rev-duo>`_ --- Covers REV's hardware and software. The control system documentation includes an introductory FTC programming tutorial.
 
 `Spectrum's Recommended Reading <https://spectrum3847.org/recommendedreading>`_ --- A list of resources collated by FRC 3847, Spectrum. While these resources are aimed at FRC, many are directly relevant to FTC.
 
@@ -142,7 +142,7 @@ Programming
 
 `FTC Robot Controller Repository <https://github.com/FIRST-Tech-Challenge/FtcRobotController>`_:highlight:`*` --- The home of the FTC SDK. Also check out the associated `wiki <https://github.com/FIRST-Tech-Challenge/FtcRobotController/wiki/>`_ and `JavaDocs <https://javadoc.io/doc/org.firstinspires.ftc>`_.
 
-`REV's Introduction to Programming <https://docs.revrobotics.com/rev-control-system/programming/hello-robot-introduction-to-programming>`_:highlight:`*` --- REV's introductory programming documentation, covering both Blocks and Java programming. Linked here is also the rest of REV's documentation for the control system.
+`REV's Introduction to Programming <https://docs.revrobotics.com/duo-control/programming/hello-robot-introduction-to-programming>`_:highlight:`*` --- REV's introductory programming documentation, covering both Blocks and Java programming. Linked here is also the rest of REV's documentation for the control system.
 
 `Controls Engineering in the FIRST Robotics Competition <https://file.tavsys.net/control/controls-engineering-in-frc.pdf>`_ --- A book that introduces students to the broader field of control theory.
 


### PR DESCRIPTION
REV changed a bunch of their documentation locations with redirects, this updates the old links to be correct.