### PR TITLE
Fix video URLs in Types of Transfers page

### DIFF
--- a/source/docs/common-mechanisms/transfers/transfer-types.rst
+++ b/source/docs/common-mechanisms/transfers/transfer-types.rst
@@ -55,7 +55,7 @@ Disadvantages
 .. raw:: html
 
    <video width="600" autoplay muted loop>
-      <source src="/_static/videos/common-mechanisms/transfers/6165-flip.mp4" type="video/mp4">
+      <source src="../../../_static/videos/common-mechanisms/transfers/6165-flip.mp4" type="video/mp4">
    </video>
 
 6165 MSET Cuttlefish, Freight Frenzy, Flip up intake, mounted on linear slides for increased horizontal reach
@@ -70,7 +70,7 @@ Disadvantages
 .. raw:: html
 
    <video width="600" autoplay muted loop>
-      <source src="/_static/videos/common-mechanisms/transfers/7236-flip.mp4" type="video/mp4">
+      <source src="../../../_static/videos/common-mechanisms/transfers/7236-flip.mp4" type="video/mp4">
    </video>
 
 7236 Recharged Green, Rover Ruckus, Flip up intake


### PR DESCRIPTION
The absolute URLs, which worked in the PR environment but not in the deploy environment, are replaced by relative ones.