### PR TITLE
Enable fail_on_warning in readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,6 +3,8 @@ version: 2
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   builder: html
+  configuration: source/conf.py
+  fail_on_warning: true
 
 # Optionally build your docs in additional formats such as PDF and ePub
 formats:

--- a/source/index.rst
+++ b/source/index.rst
@@ -1,8 +1,6 @@
 Index
 =====
 
-:doc:`/nonexistent`
-
 .. grid:: 2
    :gutter: 3
    :margin: 2

--- a/source/index.rst
+++ b/source/index.rst
@@ -1,6 +1,8 @@
 Index
 =====
 
+:doc:`/nonexistent`
+
 .. grid:: 2
    :gutter: 3
    :margin: 2


### PR DESCRIPTION
This allows issues to be spotted before they are merged.