### PR TITLE
Disable epub build, set the version to 0

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,6 @@ sphinx:
 # Optionally build your docs in additional formats such as PDF and ePub
 formats:
   - pdf
-  - epub
 
 # Optionally set the version of Python and requirements required to build your docs
 python:

--- a/source/conf.py
+++ b/source/conf.py
@@ -15,10 +15,10 @@ author = "Game Manual 0 Contributors"
 hosted_by = """Hosting Graciously Provided By //Copperforge"""
 copyright = author + " |  " + hosted_by
 
-# The full version, including alpha/beta/rc tags
-release = re.sub("^v", "", os.popen("git describe").read().strip())
-# The short X.Y version
-version = release
+# this is to be cute, with gm0's deploy model of just showing main actual
+# versions are fairly redundant
+release = "0"
+version = "0"
 
 # -- General configuration ---------------------------------------------------
 #


### PR DESCRIPTION
Having it unset causes warnings, epub builds take up extra time for no real reason.