### PR TITLE
Add empty setup function to conf.py

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -292,3 +292,6 @@ epub_title = project
 
 # A list of files that should not be packed into the epub file.
 epub_exclude_files = ["search.html"]
+
+def setup(app):
+    pass


### PR DESCRIPTION
This is so that if in the future `setup` needs to be used it is known that it does not break things; namely, with gm0-translations.