### PR TITLE
Remove broken link from Rigging page

### DIFF
--- a/source/docs/common-mechanisms/linear-motion-guide/rigging.rst
+++ b/source/docs/common-mechanisms/linear-motion-guide/rigging.rst
@@ -263,10 +263,6 @@ Retractable Coil Cord
 
 While not common within industry, coil cords are still very common (coil cord is a nearly ubiquitous staple of older telephones). Retractable coil cord is more flexible than cable carriers, stretching when extended.
 
-Here are some links to coil cord products:
-
-- `Cable Science NEC (non-electric cord) <https://www.cablescience.com/coils/nec/nec-series.html>`_
-
 Advantages:
 
 - Very space-efficient


### PR DESCRIPTION
The entire cablescience.com website seems to be broken currently, displaying the Apache2 Ubuntu Default Page on the root and it has an invalid SSL certificate.