### PR TITLE
Add FTC Docs to Useful Resources

### DIFF
--- a/source/docs/software/tutorials/vision.rst
+++ b/source/docs/software/tutorials/vision.rst
@@ -15,7 +15,7 @@ TensorFlow is Google’s machine learning technology, which can be trained to de
 
 Sample OpModes for TensorFlow being used for freight detection (Freight Frenzy) can be found `here <https://github.com/FIRST-Tech-Challenge/FtcRobotController/wiki/Blocks-Sample-Op-Mode-for-TensorFlow-Object-Detection>`__ (Blocks), and a Java example can be found `here <https://github.com/FIRST-Tech-Challenge/FtcRobotController/wiki/Java-Sample-Op-Mode-for-TensorFlow-Object-Detection>`__.
 
-FIRST has released a tool called FTC-ML to train your own TensorFlow Lite model for detecting custom objects. Details about FTC-ML can be found here `here <https://storage.googleapis.com/ftc-ml-firstinspires-prod/docs/ftc-ml_manual_2021.pdf>`__.
+FIRST has released a tool called FTC-ML to train your own TensorFlow Lite model for detecting custom objects. Details about FTC-ML can be found `on FTC Docs <https://ftc-docs.firstinspires.org/ftc_ml/index.html>`_.
 
 Vuforia
 ^^^^^^^

--- a/source/docs/useful-resources.rst
+++ b/source/docs/useful-resources.rst
@@ -16,6 +16,8 @@ General Resources
 
 `FTC Discord <https://discord.com/invite/first-tech-challenge>`_:highlight:`*` --- The **unofficial** FTC Discord server is a discussion-based community server that has teams ranging from first-year rookies to Winning Alliance Captains at the World Championships. It also has a channel for direct access to vendors.
 
+`FTC Docs <https://ftc-docs.firstinspires.org/ftc_ml/index.html>`_:highlight:`*` --- FIRST's official FTC documentation, including programming resources, team management resources and more.
+
 `FTC Q&A <https://ftc-qa.firstinspires.org>`_:highlight:`*` --- The FTC game Q&A, where clarifying questions about game rules from teams are asked and answered.
 
 `Game and Season Materials <https://www.firstinspires.org/resource-library/ftc/game-and-season-info>`_:highlight:`*` --- Where to find the information for the current season, including the Game Manuals.


### PR DESCRIPTION
Also fixes a link to something that is now on FTC Docs on the vision page.