### PR TITLE
Fix typo in finite state machine code

### DIFF
--- a/source/docs/software/concepts/finite-state-machines.rst
+++ b/source/docs/software/concepts/finite-state-machines.rst
@@ -199,7 +199,7 @@ Now, let's get into actually implementing the code for this. In a traditional ``
                        liftDump.setTargetPosition(DUMP_DEPOSIT);
 
                        liftTimer.reset();
-                       liftState = LiftState.DUMP_LIFT;
+                       liftState = LiftState.LIFT_DUMP;
                    }
                    break;
                case LiftState.LIFT_DUMP:


### PR DESCRIPTION
Correction to line 202 of the variable LiftState.DUMP_LIFT to "LiftState.LIFT_DUMP"