### PR TITLE
Add autodesk.com to linkcheck_ignore

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -64,6 +64,7 @@ mathjax_path = 'https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js'
 # Disable following anchors in URLS for linkcheck
 linkcheck_ignore = [
     r".*andymark.com.*",
+    r".*autodesk.com.*",
     r".*canva.com.*",
     r".*ftconshape.com",
 ]


### PR DESCRIPTION
autodesk.com seems to block linkcheck, both on Github Actions and on local systems, causing inaccurate linkcheck failures.