### PR TITLE
Move warning about VEX/IFI's culture

### DIFF
--- a/source/docs/hardware-components/kit-and-hardware-guide/index.rst
+++ b/source/docs/hardware-components/kit-and-hardware-guide/index.rst
@@ -22,6 +22,8 @@ Choice of a kit is a matter of many a debate in FTC forums, and each team has th
 - Tetrix (metric and imperial) is probably the simplest system to work with, but its part selection is limited, and the use of :term:`4.7mm shaft <Shaft>` with :term:`set screws <Set Screw>` is inferior to :term:`clamping hubs <Clamping Hub>` used in other systems.
 - Actobotics (imperial) is similar to goBILDA, being made by the same company. It has always been a solid option with reliable parts. For most FTC teams, goBILDA would probably be a better choice as it is more flexible and compatible, unless you already have a large stock of Actobotics parts.
 
+.. attention:: While VEX also sells some parts aimed towards FTC, **Game Manual 0 cannot endorse or support any VEX Robotics/IFI (VEX's parent company) products in any manner.** We cannot in good conscience drive people to support a business with a history of extremely concerning accusations of workplace harassment, toxicity, and general behavior that does not align with the ideals of *FIRST*\ |reg|.
+
 .. toctree::
    :maxdepth: 1
    :caption: Kit Options

--- a/source/index.rst
+++ b/source/index.rst
@@ -3,12 +3,6 @@
 Index
 =====
 
-.. warning::
-
-   Due to recent events, **Game Manual 0 cannot endorse or support any VEX Robotics/IFI (VEX's parent company) products in any manner.** We cannot in good conscience drive people to support or even *consider* buying from a business with a history of extremely concerning accusations of workplace harassment, toxicity, and general behavior that does not align with the ideals of *FIRST*\ |reg|.
-
-   These accusations and more have been collated in a `Chief Delphi thread <https://www.chiefdelphi.com/t/cw-sexual-harassment-an-open-letter-to-vex/416929>`_. (Content warning: this thread contains many potentially sensitive topics, such as sexual harassment.)
-
 .. only:: translation
 
    .. note:: This content is translated from English, and as such may include some English phrases for technical terms.


### PR DESCRIPTION
The kit/hardware guide is a better spot for this warning as it is more relevant when selecting which vendors to buy from.

The direct link to the Chief Delphi thread is removed, because it prevents the use of gm0 in some school environments.