### PR TITLE
Update Github actions versions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,8 +10,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
       with:
         python-version: 3.7
     - name: Install Python Dependencies
@@ -40,8 +40,8 @@ jobs:
   check-links:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
       with:
         python-version: 3.7
     - name: Install Dependencies
@@ -60,8 +60,8 @@ jobs:
   check-linting:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
       with:
         python-version: 3.7
     - name: Install Dependencies
@@ -73,7 +73,7 @@ jobs:
   check-spelling:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: misspell
       uses: reviewdog/action-misspell@v1
       with:
@@ -82,11 +82,11 @@ jobs:
   check-redirects:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Checkout main
       run: |
         git fetch origin main --depth=1
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v3
       with:
         python-version: 3.7
     - name: Install Dependencies

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -19,7 +19,7 @@ jobs:
       run: make linkcheck
     - name: Archive Linkcheck Failure
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: linkcheck-output.txt
         path: build/linkcheck/output.txt

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -9,8 +9,8 @@ jobs:
   check-links:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Install Dependencies


### PR DESCRIPTION
The current workflows use Node.js v12 actions, which will be disabled on September 27th; see https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Closes #362.