### PR TITLE
Fix FieldCentricMecanumTeleop imperfect strafing code.

### DIFF
--- a/source/docs/software/tutorials/mecanum-drive.rst
+++ b/source/docs/software/tutorials/mecanum-drive.rst
@@ -335,7 +335,7 @@ Field-Centric Final Sample Code
 
            while (opModeIsActive()) {
                double y = -gamepad1.left_stick_y; // Remember, Y stick value is reversed
-               double x = gamepad1.left_stick_x * 1.1; // Counteract imperfect strafing
+               double x = gamepad1.left_stick_x;
                double rx = gamepad1.right_stick_x;
 
                // This button choice was made so that it is hard to hit on accident,
@@ -350,6 +350,8 @@ Field-Centric Final Sample Code
                // Rotate the movement direction counter to the bot's rotation
                double rotX = x * Math.cos(-botHeading) - y * Math.sin(-botHeading);
                double rotY = x * Math.sin(-botHeading) + y * Math.cos(-botHeading);
+
+               rotX = rotX * 1.1;  // Counteract imperfect strafing
 
                // Denominator is the largest motor power (absolute value) or 1
                // This ensures all the powers maintain the same ratio,


### PR DESCRIPTION
The Field Centric Mecanum code applied a "imperfect strafing" factor of 1.1 to the left_stick_x value, when it should be applied to the robot-centric strafing value (which is different in a Field Centric model).  This PR corrects that.
