### PR TITLE
Set default image width/alignment with a sphinx extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 pyvenv.cfg
+source/_extensions/__pycache__/
 
 # Adapted from https://www.toptal.com/developers/gitignore/api/python
 # Environments

--- a/source/_extensions/default_image_settings.py
+++ b/source/_extensions/default_image_settings.py
@@ -6,10 +6,10 @@ from sphinx.transforms.post_transforms import SphinxPostTransform
 from sphinx.application import Sphinx
 
 
-class DefaultImageWidthTransform(SphinxPostTransform):
+class DefaultImageSettingsTransform(SphinxPostTransform):
     """
     Set a default image width for images which do not have a width attribute
-    manually set
+    manually set. Also center images which are not centered.
     """
 
     default_priority = 100  # chosen arbitrarily
@@ -31,11 +31,18 @@ class DefaultImageWidthTransform(SphinxPostTransform):
             if "width" not in node.attributes:
                 node.attributes["width"] = width
 
+            if (
+                self.app.config["default_image_centered"]
+                and "align" not in node.attributes
+            ):
+                node.attributes["align"] = "center"
+
 
 def setup(app: Sphinx) -> Dict[str, Any]:
     app.add_config_value("default_image_width_html", None, True)
     app.add_config_value("default_image_width_latex", None, True)
-    app.add_post_transform(DefaultImageWidthTransform)
+    app.add_config_value("default_image_centered", False, True)
+    app.add_post_transform(DefaultImageSettingsTransform)
 
     return {
         "parallel_read_safe": True,

--- a/source/_extensions/default_image_width.py
+++ b/source/_extensions/default_image_width.py
@@ -15,9 +15,17 @@ class DefaultImageWidthTransform(SphinxPostTransform):
     default_priority = 100  # chosen arbitrarily
 
     def run(self, **kwargs: Any) -> None:
-        width = self.app.config["default_image_width"]
+        if self.app.tags.has("html"):
+            width = self.app.config["default_width_html"]
+        elif self.app.tags.has("latex"):
+            width = self.app.config["default_width_latex"]
+        else:
+            return
+
         if not width:
-            raise ValueError("default_image_width must be set!")
+            raise ValueError(
+                "default_image_width_html/default_image_width_latex must be set!"
+            )
 
         for node in self.document.findall(nodes.image):
             if "width" not in node.attributes:
@@ -25,7 +33,8 @@ class DefaultImageWidthTransform(SphinxPostTransform):
 
 
 def setup(app: Sphinx) -> Dict[str, Any]:
-    app.add_config_value("default_image_width", None, True)
+    app.add_config_value("default_image_width_html", None, True)
+    app.add_config_value("default_image_width_latex", None, True)
     app.add_post_transform(DefaultImageWidthTransform)
 
     return {

--- a/source/_extensions/default_image_width.py
+++ b/source/_extensions/default_image_width.py
@@ -16,9 +16,9 @@ class DefaultImageWidthTransform(SphinxPostTransform):
 
     def run(self, **kwargs: Any) -> None:
         if self.app.tags.has("html"):
-            width = self.app.config["default_width_html"]
+            width = self.app.config["default_image_width_html"]
         elif self.app.tags.has("latex"):
-            width = self.app.config["default_width_latex"]
+            width = self.app.config["default_image_width_latex"]
         else:
             return
 

--- a/source/_extensions/default_image_width.py
+++ b/source/_extensions/default_image_width.py
@@ -29,7 +29,7 @@ class DefaultImageWidthTransform(SphinxPostTransform):
 
         for node in self.document.findall(nodes.image):
             if "width" not in node.attributes:
-                node.attributes["width"] = self.app.config["default_image_width"]
+                node.attributes["width"] = width
 
 
 def setup(app: Sphinx) -> Dict[str, Any]:

--- a/source/_extensions/default_image_width.py
+++ b/source/_extensions/default_image_width.py
@@ -1,0 +1,34 @@
+from typing import Any, Dict
+
+from docutils import nodes
+
+from sphinx.transforms.post_transforms import SphinxPostTransform
+from sphinx.application import Sphinx
+
+
+class DefaultImageWidthTransform(SphinxPostTransform):
+    """
+    Set a default image width for images which do not have a width attribute
+    manually set
+    """
+
+    default_priority = 100  # chosen arbitrarily
+
+    def run(self, **kwargs: Any) -> None:
+        width = self.app.config["default_image_width"]
+        if not width:
+            raise ValueError("default_image_width must be set!")
+
+        for node in self.document.findall(nodes.image):
+            if "width" not in node.attributes:
+                node.attributes["width"] = self.app.config["default_image_width"]
+
+
+def setup(app: Sphinx) -> Dict[str, Any]:
+    app.add_config_value("default_image_width", None, True)
+    app.add_post_transform(DefaultImageWidthTransform)
+
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/source/_static/custom.css
+++ b/source/_static/custom.css
@@ -1,7 +1,3 @@
-:root {
-    --image-width: 25em;
-}
-
 .wy-nav-top, .wy-nav-side, .wy-side-nav-search {
     background: #4e4a4a;
 }

--- a/source/_static/custom.css
+++ b/source/_static/custom.css
@@ -12,15 +12,6 @@ div.ethical-sidebar, div.ethical-footer {
     left: -99999px;
 }
 
-img:not(.graphviz) {
-    /* Change images to be consistent width */
-    width: var(--image-width);
-    /* Center all images so that figures and normal images have consistent styling */
-    display: block;
-    margin-left: auto;
-    margin-right: auto;
-}
-
 /* Center caption text in their respective figure */
 div.figure.align-default {
     display: flex;

--- a/source/conf.py
+++ b/source/conf.py
@@ -119,9 +119,10 @@ rediraffe_redirects = "redirects.txt"
 # Required accuracy for redirect writer
 rediraffe_auto_redirect_perc = 80
 
-# Set the default image width for all outputs.
+# Set the default image width.
 # This only applies to images without an explicit width set.
-default_image_width = "25em" if tags.has("html") else "15em"
+default_image_width_html = "25em"
+default_image_width_latex = "15em"
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -122,7 +122,7 @@ rediraffe_auto_redirect_perc = 80
 # Set the default image width.
 # This only applies to images without an explicit width set.
 default_image_width_html = "25em"
-default_image_width_latex = "15em"
+default_image_width_latex = "20em"
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -6,6 +6,11 @@
 
 import os
 import re
+import sys
+
+# add source directory to sys.path, so that we can load custom extensions
+sys.path.append(os.path.abspath("."))
+sys.path.append(os.path.abspath("./gm0/source"))
 
 # -- Project information -----------------------------------------------------
 
@@ -35,6 +40,12 @@ extensions = [
     "sphinxext.rediraffe",
     "hoverxref.extension"
 ]
+
+local_extensions = [
+    "_extensions.default_image_width"
+]
+
+extensions.extend(local_extensions)
 
 templates_path = ["_templates"]
 source_suffix = ".rst"
@@ -107,6 +118,10 @@ rediraffe_redirects = "redirects.txt"
 
 # Required accuracy for redirect writer
 rediraffe_auto_redirect_perc = 80
+
+# Set the default image width for all outputs.
+# This only applies to images without an explicit width set.
+default_image_width = "25em" if tags.has("html") else "15em"
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -42,7 +42,7 @@ extensions = [
 ]
 
 local_extensions = [
-    "_extensions.default_image_width"
+    "_extensions.default_image_settings"
 ]
 
 extensions.extend(local_extensions)
@@ -123,6 +123,8 @@ rediraffe_auto_redirect_perc = 80
 # This only applies to images without an explicit width set.
 default_image_width_html = "25em"
 default_image_width_latex = "20em"
+# Center images by default.
+default_image_centered = True
 
 # -- Options for HTML output -------------------------------------------------
 


### PR DESCRIPTION
Previously, this value was set with css. This worked fine for the HTML build, but did nothing for the LaTeX build. This way, the default width applies to all build formats.