### PR TITLE
Use ghostscript to compress PDF output on RTD

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,6 +11,10 @@ build:
     python: "3.11"
   apt_packages:
     - graphviz
+    - ghostscript
+  jobs:
+    post_build:
+      - ./scripts/rtd-compress-pdf.sh
 
 formats:
   - pdf

--- a/scripts/rtd-compress-pdf.sh
+++ b/scripts/rtd-compress-pdf.sh
@@ -5,18 +5,20 @@
 DPI=400
 PDF_DIR="$READTHEDOCS_OUTPUT/pdf"
 
-# Check if the PDF build is enabled based on if the PDF output directory exists
+# only run if the PDF build is enabled
+# based on whether or not the PDF output directory exists
 if [ -d "$PDF_DIR" ]; then
-    # find the already built PDF
+    # find the existing PDF
     pdf_name=$(ls "$PDF_DIR")
 
-    # move it into a temp directory
-    # readthedocs expects only one PDF output in the directory
+    # Read the Docs expects only one PDF file in the output directory
     # see https://docs.readthedocs.io/en/stable/reference/environment-variables.html#envvar-READTHEDOCS_OUTPUT
+    # so we move the existing PDF into a temp directory.
     temp=$(mktemp -d)
     mv "$PDF_DIR/$pdf_name" "$temp"
 
-    # actually compress the PDF
+    # compress the existing PDF into a new PDF,
+    # placed directly in the output directory
     gs -sDEVICE=pdfwrite \
         -dCompatibilityLevel=1.4 \
         -dPDFSETTINGS=/ebook \

--- a/scripts/rtd-compress-pdf.sh
+++ b/scripts/rtd-compress-pdf.sh
@@ -2,7 +2,7 @@
 
 # Compresses the PDF output using ghostscript on Read the Docs.
 
-DPI=300
+DPI=400
 PDF_DIR="$READTHEDOCS_OUTPUT/pdf"
 
 # Check if the PDF build is enabled based on if the PDF output directory exists

--- a/scripts/rtd-compress-pdf.sh
+++ b/scripts/rtd-compress-pdf.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env sh
+
+# Compresses the PDF output using ghostscript on Read the Docs.
+
+DPI=300
+PDF_DIR="$READTHEDOCS_OUTPUT/pdf"
+
+# Check if the PDF build is enabled based on if the PDF output directory exists
+if [ -d "$PDF_DIR" ]; then
+    # find the already built PDF
+    pdf_name=$(ls "$PDF_DIR")
+
+    # move it into a temp directory
+    # readthedocs expects only one PDF output in the directory
+    # see https://docs.readthedocs.io/en/stable/reference/environment-variables.html#envvar-READTHEDOCS_OUTPUT
+    temp=$(mktemp -d)
+    mv "$PDF_DIR/$pdf_name" "$temp"
+
+    # actually compress the PDF
+    gs -sDEVICE=pdfwrite \
+        -dCompatibilityLevel=1.4 \
+        -dPDFSETTINGS=/ebook \
+        -dNOPAUSE \
+        -dBATCH -dColorImageResolution="$DPI" \
+        -sOutputFile="$PDF_DIR/$pdf_name" "$temp/$pdf_name"
+fi


### PR DESCRIPTION
This significantly reduces the PDF size while barely decreasing perceptible image quality.