### PR TITLE
Add Portfolio Library/FTCScout to Useful Resources

### DIFF
--- a/source/docs/useful-resources.rst
+++ b/source/docs/useful-resources.rst
@@ -32,6 +32,8 @@ General Resources
 
 `FIRST Resource Library <https://www.firstinspires.org/resource-library?field_content_type_value%5B%5D=first_tech_challenge>`_  --- The *FIRST* resource library (filtered for FTC resources). These includes robot/field inspection checklists, robot building and programming resources, team management resources, the FTC mentor manual, and more.
 
+`Engineering Portfolio Library <https://portfolios.hivemindrobotics.net>`_ --- A library of past award-winning Engineering Portfolios. Created by Polar from FTC 23396 and managed by the community.
+
 `REV Robotics FTC Documentation <https://docs.revrobotics.com/docs/rev-duo>`_ --- Covers REV's hardware and software. The control system documentation includes an introductory FTC programming tutorial.
 
 `Spectrum's Recommended Reading <https://spectrum3847.org/recommendedreading>`_ --- A list of resources collated by FRC\ |reg| 3847, Spectrum. While these resources are aimed at FRC, many are directly relevant to FTC.
@@ -179,6 +181,8 @@ Electronics
 Team/Event Results
 ------------------
 
-`FTC Events <https://ftc-events.firstinspires.org/>`_ --- Official *FIRST* team and event result database for FTC. However, it lacks information from before Skystone.
+`FTC Events <https://ftc-events.firstinspires.org/>`_ --- Official *FIRST* team and event result database for FTC.
 
-`The Orange Alliance <https://theorangealliance.org/>`_ --- A community-run team and event result database.
+`FTC Scout <https://ftcscout.org>`_ --- A community FTC Events frontend with more features and a more slick UI.
+
+`The Orange Alliance <https://theorangealliance.org/>`_ --- A community-run team and event result database, primarily useful for its more comprehensive results before Ultimate Goal (2020-2021).


### PR DESCRIPTION
Adding FTCScout meant changing the description of The Orange Alliance and FTC Events was appropriate.