### PR TITLE
Add StemRobotics4All reference for SolidWorks CAD information + fix typo in Dassault Systèmes name.

### DIFF
--- a/source/docs/design-skills/cad.rst
+++ b/source/docs/design-skills/cad.rst
@@ -1,4 +1,5 @@
 .. include:: <isonum.txt>
+.. include:: <isolat1.txt>
 
 Computer-aided design (CAD)
 ===========================
@@ -47,7 +48,7 @@ If you're just starting out with CAD, or you don't have access to powerful compu
 `SolidWorks <https://app.smartsheet.com/b/form/6762f6652a04487ca9786fcb06b84cb5>`_
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-An industry standard CAD package made by Dassault Systèmes. It's as fully featured as CAD software gets, including great simulation features and a very robust assembly environment. It's used widely in industry and is also the program of choice for most college-level engineering classes.
+An industry standard CAD package made by Dassault Syst\ |egrave|\ mes. It's as fully featured as CAD software gets, including great simulation features and a very robust assembly environment. It's used widely in industry and is also the program of choice for most college-level engineering classes.
 
 However, **it isn't available for Mac users**, and you'll need a pretty beefy computer to run it (16GB RAM is standard). SolidWorks also comes with a solid simulation program if you wish to test the structural properties of your robot or a custom-designed part.
 

--- a/source/docs/design-skills/cad.rst
+++ b/source/docs/design-skills/cad.rst
@@ -53,6 +53,8 @@ However, **it isn't available for Mac users**, and you'll need a pretty beefy co
 
 If you have mentors or team members with previous experience in SolidWorks or an engineering class at your school that teaches SolidWorks, it will be your best choice.
 
+For a set of tutorials on how to use SolidWorks and some projects to give inspiration and show how the features can be used to design various objects and assemblies, see the stemrobotics4all.org site tutorials (https://stemrobotics4all.org/3d-modeling/solidworks/) and example projects (https://stemrobotics4all.org/3d-modeling/3d-modeling-projects/).
+
 `Inventor <https://www.autodesk.com/education/edu-software/overview?sorting=featured&page=1>`_
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/source/docs/design-skills/cad.rst
+++ b/source/docs/design-skills/cad.rst
@@ -53,8 +53,6 @@ However, **it isn't available for Mac users**, and you'll need a pretty beefy co
 
 If you have mentors or team members with previous experience in SolidWorks or an engineering class at your school that teaches SolidWorks, it will be your best choice.
 
-For a set of tutorials on how to use SolidWorks and some projects to give inspiration and show how the features can be used to design various objects and assemblies, see the stemrobotics4all.org site tutorials (https://stemrobotics4all.org/3d-modeling/solidworks/) and example projects (https://stemrobotics4all.org/3d-modeling/3d-modeling-projects/).
-
 `Inventor <https://www.autodesk.com/education/edu-software/overview?sorting=featured&page=1>`_
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/source/docs/design-skills/cad.rst
+++ b/source/docs/design-skills/cad.rst
@@ -47,7 +47,7 @@ If you're just starting out with CAD, or you don't have access to powerful compu
 `SolidWorks <https://app.smartsheet.com/b/form/6762f6652a04487ca9786fcb06b84cb5>`_
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-An industry standard CAD package made by Dassault Systemes. It's as fully featured as CAD software gets, including great simulation features and a very robust assembly environment. It's used widely in industry and is also the program of choice for most college-level engineering classes.
+An industry standard CAD package made by Dassault Systèmes. It's as fully featured as CAD software gets, including great simulation features and a very robust assembly environment. It's used widely in industry and is also the program of choice for most college-level engineering classes.
 
 However, **it isn't available for Mac users**, and you'll need a pretty beefy computer to run it (16GB RAM is standard). SolidWorks also comes with a solid simulation program if you wish to test the structural properties of your robot or a custom-designed part.
 


### PR DESCRIPTION
I have added links to the free site https://stemrobotics4all.org which contains many useful FLL and FTC resources that I believe complement Game Manual 0's content in the CAD/SolidWorks respect.

I hope the GM0 team considers these and will eventually incorporate them.

I can fully vouch for the quality of the resources.

Thank you,
MDNich (10738 alum, 27743 (FLL) alum).