### PR TITLE
Bump python version for linkcheck

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
-        python-version: 3.7
+        python-version: "3.11"
     - name: Install Dependencies
       run: pip install -r source/requirements.txt
     - name: Check Links


### PR DESCRIPTION
The old python version no longer works with the new dependencies, which causes link check to fail no matter what. This was missed because link check was disabled due to inactivity on the repo.