### PR TITLE
Award Categories section update

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -59,6 +59,8 @@ rst_epilog = """
 .. |gm0| replace:: Game Manual 0
 .. |gm1| replace:: Game Manual Part 1
 .. |gm2| replace:: Game Manual Part 2
+.. |CM| replace:: Competition Manual
+.. |EP| replace:: Engineering Portfolio
 .. |EN| replace:: Engineering Notebook
 """
 # Enable hover content on glossary terms

--- a/source/docs/awards/award-types.rst
+++ b/source/docs/awards/award-types.rst
@@ -6,7 +6,7 @@ Award Categories
 Advancing Awards
 ----------------
 
-There are 7 awards for FTC\ |reg| teams (excluding optional awards). For more information on the exact requirements for these awards, see |gm1|. In order of advancement priority, these are:
+There are 7 awards for FTC\ |reg| teams (excluding optional awards). For more information on the exact requirements for these awards, see |CM|. In order of advancement priority, these are:
 
 .. glossary::
 
@@ -15,86 +15,76 @@ There are 7 awards for FTC\ |reg| teams (excluding optional awards). For more in
 
       In order to win the Inspire Award, your team should focus on every other award category, and perform well in the robot game. In the past, the Inspire Award has given much more weight to awards performance, but it seems as if the judges are now taking robot performance into consideration more.
 
-      Of all the awards, this one is arguably the most subjective, as it is about how good does a team does overall, including and how much they weigh outreach as compared to robot performance along with documentation.
+      Of all the awards, this one is arguably the most subjective, as it is about how good a team does overall, including and how much they weigh outreach as compared to robot performance along with documentation.
 
-      Official Game Manual Description
-         This judged award is given to the team that best embodies the 'challenge' of the *FIRST*\ |reg| Tech Challenge program. The Team that receives this award is a strong ambassador for *FIRST* programs and a role model *FIRST* Team. This Team is a top contender for many other judged awards and is a gracious competitor. The Inspire Award winner is an inspiration to other Teams, acting with Gracious Professionalism\ |reg| both on and off the playing field. This Team shares their experiences, enthusiasm and knowledge with other teams, sponsors, their community, and the Judges. Working as a unit, this Team will have shown success in performing the task of designing and building a Robot.
+      Official |CM| Description
+         The team that receives this award is a strong ambassador for *FIRST*\ |reg| programs and a role model *FIRST* team. This team is a top contender for many other judged awards and is a gracious competitor. The Inspire Award winner is an inspiration to other teams, acting with *Gracious Professionalism* |reg| both on and off the playing field. This team shares their experiences, enthusiasm and knowledge with other teams, sponsors, their community, and the judges. Working as a unit, this team will have shown success in performing the task of designing and building a robot.
 
    Think Award
-      The Think Award is based entirely on the |EN| and Engineering Portfolio. In order to have a chance at winning, the |EN| should include as much math and physics as possible, document the entire journey of the robot through iterations, and other documentation of design and game strategy.
+      The Think Award is based entirely on the |EP|. In order to have a chance at winning, the |EP| should include as much math and physics as possible, document the entire journey of the robot through iterations, and other documentation of design and game strategy.
 
-      In addition, the portfolio should be well laid out and contain information on various non-technical aspects of the team, such as sustainability (recruitment of new team member and mentors), training, outreach (especially the impact of the outreach and what was learned from it), and team structure. While these categories aren't as strictly important as robot documentation, they are generally recommended for a strong engineering portfolio.
+      In addition, the portfolio should be well laid out and contain information on various non-technical aspects of the team, such as sustainability (recruitment of new team member and mentors), training, outreach (especially the impact of the outreach and what was learned from it), and team structure. While these categories aren't as strictly important as robot documentation, they are generally recommended for a strong |EP|.
 
-      Official Game Manual Description
-         This judged award is given to the Team that best reflects the journey the Team took as they experienced the engineering design process during the build season. The engineering content within the portfolio is the key reference for judges to help identify the most deserving Team. The Teams engineering content must focus on the design and build stage of the Team's Robot.
+      Official |CM| Description
+         This judged award is given to the team that best reflects the journey the team took as they experienced the engineering design process during the build season. The engineering content within the portfolio is the key reference for judges to help identify the most deserving team. The team could share or provide additional detailed information that is helpful for the judges.
 
          The Team must be able to share or provide additional detailed information that is helpful for the judges. This could include descriptions of the underlying science and mathematics of the Robot design and game strategies, the designs, redesigns, successes, and opportunities for improvement. A Team is not a candidate for this award if their portfolio does not include engineering content.
 
    Connect Award
-      The Connect Award is one of the two outreach awards. This award is for teams that work with their local STEM community and corporate community. Unfortunately, the line between the Connect and Motivate award can be vague, and judges may not differentiate which outreach falls under which award.
+      The Connect Award is one of the two outreach awards. This award is for teams that work with their local STEM community and corporate community. Unfortunately, the line between the Connect award and Motivate award can be vague, and judges may not differentiate which outreach falls under which award.
 
-      Look at the section about differentiating connect and motivate for more advice on this. For both outreach awards, a Team Plan is required. Refer to the section about writing a team plan for advice.
+      Look at the section about differentiating Connect and Motivate for more advice on this. For both outreach awards, a Team Plan is required. Refer to the section about writing a team plan for advice.
 
       A portfolio is also required for this award, and should contain descriptions of the outreach as well as what the team gained from the outreach. In addition, the portfolio should also contain information on plans for recruitment of mentors as well as how the team plans to meaningfully develop their STEM connections.
 
       Be prepared for judges to ask you how your outreaches were meaningful, and try to avoid doing STEM outreaches just for the sake of saying you did a STEM outreach. Successful STEM outreaches are those that are undertaken for a specific purpose and have a clear intent and goal, such as meeting with an expert on computer vision to ask for advice on a vision task for the game. If you are struggling to find STEM outreaches, local colleges and businesses are a good start.
 
-      Official Game Manual Description
-         This judged award is given to the Team that most connects with their local science, technology, engineering, and math (STEM) community. A true *FIRST* team is more than a sum of its parts and recognizes that engaging their local STEM community plays an essential part in their success. The recipient of this award is recognized for helping the community understand *FIRST*, the *FIRST* Tech Challenge, and the Team itself. The Team that wins the Connect Award aggressively seeks and recruits engineers and explores the opportunities available in the world of engineering, science and technology. This Team has a clear Team plan and has identified steps to achieve their goals.
+      Official |CM| Description
+         This judged award is given to the team that connects with their local science, technology, engineering, and math (STEM) community. A true *FIRST* team is more than a sum of its parts and recognizes that engaging their local STEM community plays an essential part in their success. This team has a team plan and has identified steps to achieve their goals. A portfolio is not required for this award.
 
    Innovate Award
-      The Innovate award is what it sounds like - it's for teams with innovative robots or robot mechanisms.
+      The Innovate Award is what it sounds like - it's for teams with innovative robots or robot mechanisms.
 
-      The Innovate award is mainly for hardware, but some teams have been able to also present software as innovative. Some judges think it's great to present software as part of innovation, but others feel that software only fits under Control.
+      The Innovate Award is mainly for hardware, but some teams have been able to also present software as innovative. Some judges think it's great to present software as part of innovation, but others feel that software only fits under Control.
 
       While it may be tempting to sell your entire robot as innovative, it is often much more effective to focus on one or two aspects of your robot instead. Judges will often ask what the most innovative part of your robot is, and this is your opportunity to focus in on the one or two mechanisms that you can sell.
 
-      The engineering portfolio should contain information on your robot's mechanisms, and your presentation should also mention the innovative parts of your robot. However, refrain from over describing the mechanisms you intend to sell as innovative, as you want to leave room for the judges to ask questions, which gives you more opportunities and time to sell your mechanisms. In addition, practice what aspects of the mechanisms you want to sell as innovative, and make sure you are able to thoroughly describe why they are innovative when asked.
+      The |EP| should contain information on your robot's mechanisms, and your presentation should also mention the innovative parts of your robot. However, refrain from over describing the mechanisms you intend to sell as innovative, as you want to leave room for the judges to ask questions, which gives you more opportunities and time to sell your mechanisms. In addition, practice what aspects of the mechanisms you want to sell as innovative, and make sure you are able to thoroughly describe why they are innovative when asked.
 
-      Official Game Manual Description
-         The Innovate Award celebrates a Team that thinks imaginatively and has the ingenuity, creativity, and inventiveness to make their designs come to life. This judged award is given to the Team that has the most innovative and creative Robot design solution to any specific components in the *FIRST* Tech Challenge game. Elements of this award include elegant design, robustness, and 'out of the box' thinking related to design. This award may address the design of the whole Robot or of a sub-assembly attached to the Robot. The creative component must work consistently, but a Robot does not have to work all the time during Matches to be considered for this award. The Team's engineering portfolio must include a summary of the design of the component or components and the Team's Robot to be eligible for this award. Entries must describe how the Team arrived at their solution.
+      Official |CM| Description
+         The Innovate Award celebrates a team that thinks imaginatively and has the ingenuity, creativity, and inventiveness to make their designs come to life. This judged award is given to the team that has an innovative and creative robot design solution to any specific components in the *FIRST* Tech Challenge game. Elements of this award include design, robustness, and creative thinking related to design. This award may address the design of the whole robot or of a mechanism attached to the robot and does not have to work all the time during matches to be considered for this award. A portfolio is not required for this award.
 
    Control Award
       The Control award is meant to recognize a team that has a good software solution to make their robot "intelligent". It's known as the "software award" and is for the team with the best or most innovative software and sensor solution for the game.
 
-      Don't be tempted to overlook the control award even though it doesn't advance at most competitions. The control award counts for the inspire award, and strong performance in control counts towards inspire ranking.
+      Don't be tempted to overlook the control award even though it doesn't advance at most competitions. The control award counts for the Inspire Award, and strong performance in control counts towards inspire ranking.
 
-      This award requires a separate submission sheet which is a condensed summary of a team's software. Check your region's rules, some require `the traditional (in person) <https://www.firstinspires.org/sites/default/files/uploads/resource_library/ftc/control-award-submission-form-traditional.pdf>`_ or `remote <https://www.firstinspires.org/sites/default/files/uploads/resource_library/ftc/control-award-submission-form-remote.pdf>`_ form, but some accept custom forms. Check with your affiliate partner or judges if you are unsure. **Do not directly put code into your portfolio, control award sheet or notebook, the judges will not care**. Instead, focus on explaining key algorithms that you use, and explain the software in an easy to understand way. Remember, your control award judges may not be software engineers or programmers, so make sure you can explain everything to someone without a software background.
+      **Do not directly put code into your portfolio, the judges will not care**. Instead, focus on explaining key algorithms that you use, and explain the software in an easy to understand way. Remember, your Control Award judges may not be software engineers or programmers, so make sure you can explain everything to someone without a software background.
 
-      In addition, control award software is more then just your autonomous mode programs. Driver assistance, feedback, and automation all are vital to the control award.
+      In addition, Control Award software is more then just your autonomous mode programs. Driver assistance, feedback, and automation all are vital to the Control Award.
 
-      Official Game Manual Description
-         The Control Award celebrates a Team that uses sensors and software to increase the Robot's functionality in the field. This award is given to the Team that demonstrates innovative thinking to solve game challenges such as autonomous operation, improving mechanical systems with intelligent control, or using sensors to achieve better results. The control component should work consistently in the field. The Team's engineering portfolio must contain a summary of the software, sensors, and mechanical control, but would likely not include copies of the code itself.
-
-      Some examples of control award sheets are:
-
-      - `11115 Gluten Free Rover Ruckus <https://docs.google.com/document/d/1dXtv628kQRlMkslx5xFYXEXGucp7-IyfMthEEfNveQ4/edit>`_
-      - `11115 Gluten Free Skystone <https://docs.google.com/document/d/18laHXP-aKpkPc_QzlaC5b9aeHVzLxlHNPuzaLOYh84Y/edit>`_
-      - `1002 Circuit Runners Green Skystone <https://docs.google.com/document/d/1jwoP1ZpFJdSB36ybrIu1igLV8cwLweD767LLgi7pX6Y/edit>`_
-      - `9866 VIRUS Skystone <https://drive.google.com/file/d/1hWp07uPvID0qbwyuOulewDEwrAl6lpMA/view>`_
-      - `5143 Xcentrics Skystone <https://docs.google.com/document/d/1HuuHvmBrM-qRmuz3W7KvYm7uiQcRyLXmuo-KRQFgw4E/edit>`_
-      - `11528 Bots of Prey Skystone <https://drive.google.com/file/d/1PEFclEL5nApEOcNh-k4O4m94mGgoa35u/view?usp=sharing>`_
-      - `9794 Wizards.exe Skystone <https://drive.google.com/file/d/1YS9scvXvqHFiqJL1beXzEUJmslHtX0IS/view?usp=sharing>`_
+      Official |CM| Description
+         The Control Award celebrates a Team that uses sensors and software to increase the Robot's functionality in the field. This award is given to the Team that demonstrates innovative thinking to solve game challenges such as autonomous operation, improving mechanical systems with intelligent control, or using sensors to achieve better results. The control component should work consistently in the field. The Team's |EP| must contain a summary of the software, sensors, and mechanical control, but would likely not include copies of the code itself.
 
    Motivate Award
-      The Motivate Award is one of the two outreach awards. It's for teams that work with their local and *FIRST* community. Unfortunately, the line between the :term:`connect award <Connect Award>` and motivate award can be vague, and most judges don't know how to differentiate which outreach falls under which award.
+      The Motivate Award is one of the two outreach awards. It's for teams that work with their local and *FIRST* community. Unfortunately, the line between the :term:`Connect Award <Connect Award>` and Motivate Award can be vague, and most judges don't know how to differentiate which outreach falls under which award.
 
       Look at the section about differentiating connect and motivate for more advice on this. For both outreach awards, a Team Plan is required. Refer to the section about writing a team plan for advice.
 
-      The key aspects to include in your portfolio and presentation for motivate is showing how all team members contribute to the success of the team, how your team is recruiting members from non-stem areas, as well as plans for fundraising, funding, sustainability, and recruitment.
+      The key aspects to include in your portfolio and presentation for Motivate is showing how all team members contribute to the success of the team, how your team is recruiting members from non-stem areas, as well as plans for fundraising, funding, sustainability, and recruitment.
 
-      Official Game Manual Description
-         This Team embraces the culture of *FIRST* and clearly shows what it means to be a team. This judged award celebrates the Team that represents the essence of the *FIRST* Tech Challenge competition through Gracious Professionalism and general enthusiasm for the overall philosophy of *FIRST* and what it means to be a *FIRST* Tech Challenge Team. This is a Team who makes a collective effort to make *FIRST* known throughout their school and community, and sparks others to embrace the culture of *FIRST*.
+      Official |CM| Description
+         This team embraces the culture of *FIRST* and shows what it means to be a team. This team makes a collective effort to make *FIRST* known throughout their school and community and sparks others to embrace *FIRST*'s culture. A portfolio is not required for this award.
 
    Design Award
       The Design Award is one of the robot awards that primarily focuses on the hardware aspect of the robot. It is for robots that are both functional, aesthetic, and use good design practices, including CAD.
 
-      In order to be considered for the Design Award, it's recommended that your team uses CAD and designs the robot before it is built, with engineering portfolio sections about the development of the robot through iterations of the engineering design process. Its important to include CAD screenshots and drawings in your portfolio, and your design should be consistent with any team goals listed.
+      In order to be considered for the Design Award, it's recommended that your team uses CAD and designs the robot before it is built, with |EP| sections about the development of the robot through iterations of the engineering design process. Its important to include CAD screenshots and drawings in your portfolio, and your design should be consistent with any team goals listed.
 
       While functionality is what most teams focus on, the Design Award also takes into account aesthetics, and most judges will generally be turned off by an ugly robot for this award (no cardboard on the robot!), so make sure your robot looks presentable.
 
-      Official Game Manual Description
-         This judged award recognizes design elements of the Robot that are both functional and aesthetic. The Design Award is presented to Teams that incorporate industrial design elements into their solution. These design elements could simplify the Robot's appearance by giving it a clean look, be decorative in nature, or otherwise express the creativity of the Team. The Robot should be durable, efficiently designed, and effectively address the game challenge.
+      Official |CM| Description
+         The Design Award celebrates the team that demonstrates industrial design principles, striking a balance between form, function, and aesthetics. The design process used should result in a robot which is efficiently designed, and effectively addresses the game challenge. A portfolio is not required for this award.
 
 Connect vs Motivate
 ^^^^^^^^^^^^^^^^^^^
@@ -117,8 +107,8 @@ Tips for Both
 - Present numbers, but only emphasize them if they're large with a wow factor
    - Make sure your numbers are somewhat accurate! If you are at a large event, you can get a rough headcount from the organizers, but its generally better to know roughly how many people actually stopped and looked at your team.
 - Present stories to the judges, not just overviews. Tell personal stories.
-- Log all your outreach events, with who went and how many hours each person did in its own place separate from the engineering notebook. This makes it easier to compile total numbers and shows the judges every outreach activity/event in one place.
-- For a bigger impact make sure you have more resources then just your team's information at an event, having details for *FIRST* Lego League teams in addition to your *FIRST* Tech Challenge information can broaden how many people you reach.
+- Log all your outreach events, with who went and how many hours each person did in its own place separate from the |EP|. This makes it easier to compile total numbers and shows the judges every outreach activity/event in one place.
+- For a bigger impact make sure you have more resources than just your team's information at an event, having details for *FIRST* Lego League teams in addition to your *FIRST* Tech Challenge information can broaden how many people you reach.
 - Follow up, follow up, follow up! If a person gives you a business card or a student expresses interest, it doesn't hurt to follow up if they don't reach out as promised. People can forget or get busy, sometimes a reminder is useful!
 
 Optional Awards
@@ -131,15 +121,8 @@ There are some awards that events are not required to present; these do not adva
    Judges Choice Award
       The Judges Choice Award is meant to recognize a team that doesn't fit into any of the existing award categories, but the judges still felt the team deserved to win an award for their outstanding effort or other experience. This award is very subjective, and doesn't advance teams. It is also optional to give at every competition, but in some regions given at every competition unless the judges don't find a deserving team.
 
-   Promote Award and Compass Award
-      The Promote and Compass awards are optional awards that are usually given only at state championships and world championships. These awards do not require an engineering notebook to win, but do not advance teams. They are submitted as a video no longer than 1 minute. The Promote award is for creating a PSA for *FIRST* with a specific video prompt. This prompt changes every year, and is found in |gm1|. The Compass award is for recognizing an outstanding mentor. Submitting these awards is usually done on a case-by-case basis, where the event organizer sends teams instructions on how to submit.
-
-      Some good Promote award submissions include:
-
-      - `Team 3595 in 2014 <https://www.youtube.com/watch?v=yYFxuJwtCu0>`_
-      - `Team 8808 in 2017 <https://www.youtube.com/watch?v=7yjGMYbtKU0>`_
-      - `Team 5795 in 2017 <https://www.youtube.com/watch?v=8gn-URpmXVA>`_
-      - `Team 4924 in 2016 <https://www.youtube.com/watch?v=lYaKEnutiR4>`_
+   Compass Award
+      The Compass Award is an optional award that is usually given only at state championships and world championships. This award does not require an |EP| to win, but does not advance teams. It's submitted as a video no longer than 1 minute. The Compass Award is for recognizing an outstanding mentor. Submitting this award is usually done on a case-by-case basis, where the event organizer sends teams instructions on how to submit.
 
       Some good Compass award submissions include:
 
@@ -148,4 +131,4 @@ There are some awards that events are not required to present; these do not adva
       - `Team 9879 in 2017 <https://www.youtube.com/watch?v=z6M6UYMLujo>`_
       - `Team 6510 in 2015 <https://www.youtube.com/watch?v=E76ij2H3YF4>`_
 
-      For more information on these awards, take a look at the specific section for each award in |gm1|.
+For more information on these awards, take a look at the specific section for each award in |CM|.


### PR DESCRIPTION
While translating to Russian we noticed that Award Categories is kinda outdated. We updated it a little bit so now section uses modern terms (for example Engineering Portfolio instead of Engineering Notebook) and new definitions from current competition manual.

Also I saw you use |gm1|, |gm2| and |EN| (outdated macroses) so I added |CM| (Competition Manual) and |EP| (Engineering Portfolio) to keep it simple for next usages