### PR TITLE
Show icon for external links; open external links in new tab

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -36,6 +36,7 @@ extensions = [
     "sphinx.ext.mathjax",
     "sphinx_design",
     "sphinx_favicon",
+    "sphinx_new_tab_link",
     "sphinxext.opengraph",
     "sphinxext.rediraffe",
     "sphinxcontrib.rsvgconverter",
@@ -339,3 +340,6 @@ locale_dirs = ["locale/"]
 
 # -- GraphViz configuration ----------------------------------
 graphviz_output_format = 'svg'
+
+# Show icon for external links (https://github.com/ftnext/sphinx-new-tab-link/tree/main?tab=readme-ov-file#new_tab_link_show_external_link_icon)
+new_tab_link_show_external_link_icon = True

--- a/source/requirements.txt
+++ b/source/requirements.txt
@@ -46,6 +46,7 @@ sphinxcontrib-qthelp==2.0.0 ; python_version >= "3.10" and python_version < "4.0
 sphinxcontrib-serializinghtml==2.0.0 ; python_version >= "3.10" and python_version < "4.0"
 sphinxext-opengraph==0.9.1 ; python_version >= "3.10" and python_version < "4.0"
 sphinxext-rediraffe==0.2.7 ; python_version >= "3.10" and python_version < "4.0"
+sphinx_new_tab_link==0.8.0 ; python_version >= "3.10" and python_version < "4.0"
 starlette==0.38.2 ; python_version >= "3.10" and python_version < "4.0"
 stevedore==5.2.0 ; python_version >= "3.10" and python_version < "4.0"
 tempdir==0.7.1 ; python_version >= "3.10" and python_version < "4.0"


### PR DESCRIPTION
I kept coming across instances where the lack of differentiation between external links an non-external links was somewhat confusing.  This fixes any potential for confusion, while also making external links open a new tab when clicked.

Before:
<img width="3456" height="1972" alt="image" src="https://github.com/user-attachments/assets/8bf934fa-15c7-421f-971c-462ac74a30f8" />

After: 
<img width="3456" height="1972" alt="image" src="https://github.com/user-attachments/assets/eabbdf8f-da74-4a9a-ae72-4d1f3dca5308" />
