### PR TITLE
Fix a bunch of typos

### DIFF
--- a/source/docs/being-a-team/team-organization.rst
+++ b/source/docs/being-a-team/team-organization.rst
@@ -39,7 +39,7 @@ This is the most important knowledge-related pointer, in my opinion. Having all 
 Create a training program for your recruits.
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-When new members join your team, some of them will probably not know how to build and program a robot, or may have experiences with different techniques and softwares. Document a specific onboarding program for your new members - what logins will you have to give them? What softwares will they need to learn? What are some design techniques they will have to learn? Assign dedicated members to teach younger members about these techniques and to share their knowledge.
+When new members join your team, some of them will probably not know how to build and program a robot, or may have experiences with different techniques and software. Document a specific onboarding program for your new members - what logins will you have to give them? What software will they need to learn? What are some design techniques they will have to learn? Assign dedicated members to teach younger members about these techniques and to share their knowledge.
 
 Gracious Professionalism
 ------------------------

--- a/source/docs/common-mechanisms/power-transmission/gears.rst
+++ b/source/docs/common-mechanisms/power-transmission/gears.rst
@@ -77,7 +77,7 @@ Disadvantages
 -------------
 
 - **Sometimes, the ratio you want might not be easy to build**. Channel spacing limits gear ratios, but this can be circumvented with compound ratios and a bit of creativity.
-- **Long distance power transfer is impractical with gears**. If you need to transfer power long distances, gear combinations can become complicated very quickly, so belt/chain is preferrable.
+- **Long distance power transfer is impractical with gears**. If you need to transfer power long distances, gear combinations can become complicated very quickly, so belt/chain is preferable.
 - **Meshing gears can be tricky**. It's only made worse by the sensitivity of a gear mesh. However, channels do solve this problem, providing pre-spaced holes to easily mesh your gears. Do keep in mind that gear mesh may not be perfect, even with channel.
 - **Gears usually wear faster than sprockets** if there is too much friction between the gears. Teams can use white lithium grease or similar lubricant to help remedy this problem.
 

--- a/source/docs/common-mechanisms/transfers/transfer-types.rst
+++ b/source/docs/common-mechanisms/transfers/transfer-types.rst
@@ -134,7 +134,7 @@ Roller Conveyor
 Roller conveyors use a series of rollers or wheels to move objects from the beginning of the conveyor to the end. These transfers allow for the use of compliant wheel for different or odd shaped items, but care must be taken that objects don't get stuck in between rollers. In addition, wheels tend to have better grip then many forms of continuous conveyors. Surgical tubing can also be used instead of rollers.
 
 .. figure:: images/7244-roller.jpg
-   :alt: 7244 Roller Conveyor intake, where a series of omni wheels moves a game element verticall
+   :alt: 7244 Roller Conveyor intake, where a series of omni wheels moves a game element vertical
 
    7244 OUT of the BOX Robotics, Ultimate Goal, Roller conveyor transfer intake, where a series of omni wheels moves the game element rings at a high vertical angle
 

--- a/source/docs/design-skills/design-glossary.rst
+++ b/source/docs/design-skills/design-glossary.rst
@@ -16,4 +16,4 @@ Design Glossary
       Packaging refers to the relative size and location of components on the robot. Generally, you want to design and locate (or package) components in the most space-efficient way you can.
 
    STEP file
-      A STEP file is a filetype used to store 3D data about a part. It is recognized by different CAD softwares including SolidWorks, Inventor, Creo, etc.
+      A STEP file is a filetype used to store 3D data about a part. It is recognized by different CAD software including SolidWorks, Inventor, Creo, etc.

--- a/source/docs/design-skills/design-strategy.rst
+++ b/source/docs/design-skills/design-strategy.rst
@@ -186,4 +186,4 @@ Fully driver-controlled driving |rarr| Partially automated tasks
 #. Automating tasks can save time and reduce the need for driver multi-tasking. Drivers should always be controlling the robot with as few button presses as possible. For example, automatically stopping the intake mechanism when game elements have been collected saves a button press.
 #. Autonomously operating some mechanisms has the advantage of eliminating driver error and relieves stress. For example, if a lift has to extend to exactly 30 inches, a motor with an :term:`encoder <Encoder>` can complete that with 100% accuracy at full speed, compared to a human driver's minor error.
 
-.. note:: Autonomous functions should be able to be overrided by manual input in case something goes wrong (e.g. encoder is unplugged, a part breaks, etc.) to prevent damage to the robot and to be compliant with game rules.
+.. note:: Autonomous functions should be able to be overridden by manual input in case something goes wrong (e.g. encoder is unplugged, a part breaks, etc.) to prevent damage to the robot and to be compliant with game rules.

--- a/source/docs/hardware-components/fastener-guide.rst
+++ b/source/docs/hardware-components/fastener-guide.rst
@@ -200,6 +200,6 @@ Bolts on your robot may loosen over time, especially if there are heavy vibratio
          Also note: **THE BOTTLE COLOR AND THE FLUID COLOR ARE REVERSED.** When we refer to the "color", we mean the fluid color. Blue loctite usually comes in a red bottle.
 
       .. figure:: images/loctite.png
-         :alt: A red bottle containing blue (removable) loctite, and a blue bottle containing red (permament) loctite
+         :alt: A red bottle containing blue (removable) loctite, and a blue bottle containing red (permanent) loctite
 
-         Blue Loctite (removable, in red tube), Red Loctite (permament, in blue tube)
+         Blue Loctite (removable, in red tube), Red Loctite (permanent, in blue tube)

--- a/source/docs/know-your-lingo.rst
+++ b/source/docs/know-your-lingo.rst
@@ -17,7 +17,7 @@ League Tournament
 Alliance
    Group of two or, in eliminations, two or three teams that compete. In elimination matches each team must play at least once.
 Ranking Points (RP)
-   Primary basis in rankings at traditional events. For the Power Play season, each team receives 2 RP for winning a qualification match, 1 for tieing, and 0 for losing.
+   Primary basis in rankings at traditional events. For the Power Play season, each team receives 2 RP for winning a qualification match, 1 for tying, and 0 for losing.
 TieBreaker Points (TBP)
    Secondary determinant in team rankings for traditional events, primary determinant for remote events. For the Power Play season, this is split up into two parts; TBP1 and TBP2. TBP1 is used before TBP2, and is
    the alliances/teams autonomous period score. TBP2 is the alliances/teams end game score. (Whether it is alliances/teams depends on if the team is at traditional events, respectively.)

--- a/source/docs/power-and-electronics/sensor-glossary.rst
+++ b/source/docs/power-and-electronics/sensor-glossary.rst
@@ -64,7 +64,7 @@ Logic Level Converter
 
 The old Modern Robotics system run on 5v sensor logic. The new REV Robotics system uses 3.3v. For most off the shelf sensors, this doesn't cause any problems, but for some existing FTC sensors it does. To solve this REV sells boards, called `logic level converters <https://www.revrobotics.com/rev-31-1389/>`_, that convert the sensor data to be readable by the REV hubs. The `REV Expansion Hub <https://docs.revrobotics.com/duo-control/sensors/5v-sensors#logic-level-converter>`_ guide has a chart detailing what adapters are needed for what sensors.
 
-.. attention:: According to REV testing, goBILDA, REV and TorqueNado motors don't need logic level converters, but only some NeveRest motors worked with no discernable reason why.
+.. attention:: According to REV testing, goBILDA, REV and TorqueNado motors don't need logic level converters, but only some NeveRest motors worked with no discernible reason why.
 
 It is ideal to not use logic level converters to simplify your wiring. If you need to, there is a best practice. Electrical tape the connectors on either end, this helps with static, and it keeps it from being physically disconnected. This does produce a very noticeable effect with encoders on fields with lots of static.
 

--- a/source/docs/power-and-electronics/servo-guide/choosing-servo.rst
+++ b/source/docs/power-and-electronics/servo-guide/choosing-servo.rst
@@ -136,6 +136,6 @@ Specialty Servos
 ^^^^^^^^^^^^^^^^
 
 - `goBILDA 5 Turn Servo <https://www.gobilda.com/2000-series-5-turn-dual-mode-servo-25-2-torque/>`_
-   - goBILDA manufactures all three of their Dual Mode servos (Speed, Super Speed, Torque) in 5 turn varients, which can rotate 5 turns while still tracking position. These servos have high range, making them ideal for use with external gearboxes, but are more expensive and have a lower precision than the normal varients.
+   - goBILDA manufactures all three of their Dual Mode servos (Speed, Super Speed, Torque) in 5 turn variants, which can rotate 5 turns while still tracking position. These servos have high range, making them ideal for use with external gearboxes, but are more expensive and have a lower precision than the normal variants.
 
 REV and goBILDA :term:`servos <Servo>` can be purchased from REV and goBILDA websites respectively. For all other servos, some good sources are `ServoCity <https://www.servocity.com/>`_ or `Amazon <https://www.amazon.com/>`_.

--- a/source/docs/software/getting-started/common-issues.rst
+++ b/source/docs/software/getting-started/common-issues.rst
@@ -8,7 +8,7 @@ Common Issues
 Exceptions
 ----------
 
-Exceptions are events that occur during the execution of a program, disrupting the normal flow of instructions, used in error events or problems that arise during runtime. A exception can be catched to avoid propagation, otherwise any exception that's not handled will cause the program flow to stop immediately.
+Exceptions are events that occur during the execution of a program, disrupting the normal flow of instructions, used in error events or problems that arise during runtime. A exception can be caught to avoid propagation, otherwise any exception that's not handled will cause the program flow to stop immediately.
 
 Some common types of exceptions include:
 
@@ -167,7 +167,7 @@ OpModes are *strictly controlled programs*, in the sense that the SDK requires t
 
    }
 
-If you need to run any sort of lenghty action in your OpMode, another option would be using a LinearOpMode instead.
+If you need to run any sort of lengthy action in your OpMode, another option would be using a LinearOpMode instead.
 
 LinearOpModes are less strict since their single ``runOpMode()`` method can flow more freely, but they still need to be cooperative to stop requests. Take the following code as an example:
 

--- a/source/docs/software/tutorials/gamepad.rst
+++ b/source/docs/software/tutorials/gamepad.rst
@@ -223,7 +223,7 @@ Gamepad feedback (i.e. rumble and LED control) can be a helpful way for robots t
       - Rumble: contains both left and right rumble motors, but both seem to be only small weight (bzzz)
       - LED Control: control of RGB LED (solid color or pattern). LED is fairly small and dim and may not be a good choice.
 
-.. tip:: Gamepad feedback can be used to alert drivers of: start of endgame, intake loaded, automatic aligment complete, etc.
+.. tip:: Gamepad feedback can be used to alert drivers of: start of endgame, intake loaded, automatic alignment complete, etc.
 
 
 Rumble


### PR DESCRIPTION
I found these by using the [typos tool](https://github.com/crate-ci/typos/), which should probably be automated in a CI check of some sort, in the spirit of linkcheck/linkcheckdiff.

If that was the case, we would have to add some exceptions; namely, KNO3 and HiTechnic.