### PR TITLE
Remove outdated links from Options for Programming

### DIFF
--- a/source/docs/software/getting-started/options-for-programming.rst
+++ b/source/docs/software/getting-started/options-for-programming.rst
@@ -82,7 +82,7 @@ Disadvantages
 ^^^^^^^^^^^^^
 
 - Connecting to the robot controller's Wi-Fi network will prevent you from using anything on the internet including video tutorials and online communication, unless you have a second Wifi adapter (cheap and easy)
-- Relatively easy setup process, but time consuming and is a hefty install (3GB of files between Android Studio, ftc_app, and other libraries)
+- Relatively easy setup process, but time consuming and is a hefty install (3GB of files between Android Studio, FtcRobotController, and other libraries)
 - Issues can be difficult to diagnose and solve
 
 Other Programming Languages

--- a/source/docs/software/getting-started/options-for-programming.rst
+++ b/source/docs/software/getting-started/options-for-programming.rst
@@ -68,21 +68,16 @@ Advantages
 
 - Recommended if you're learning or have learned some programming, even better if you know a little Java.
 - Much greater flexibility than Blocks.
-- Much easier to integrate libraries like `EasyOpenCV`_, `FTC Dashboard`_, `FTCLib`_, and `Road Runner`_.
+- Much easier to integrate libraries like `FTC Dashboard`_, `FTCLib`_, and `Road Runner`_.
 - Can use plugins like `Road Runner`_.
 - Can use either a USB connection to the :term:`RC <Robot Controller>` phone, or a wireless connection to upload code.
-
-  .. note:: Deploy times can be sped up by using `OpenRC Turbo`_.
-
 - Can debug in real-time
 - Many resources for Java, Android Studio, and IDEA
 - Can use other programming languages
 
-.. _EasyOpenCV: https://github.com/openftc/easyopencv
 .. _FTC Dashboard: https://github.com/acmerobotics/ftc-dashboard
 .. _FTCLib: https://github.com/ftclib/ftclib
 .. _Road Runner: https://github.com/acmerobotics/road-runner
-.. _OpenRC Turbo: https://github.com/OpenFTC/OpenRC-Turbo
 
 Disadvantages
 ^^^^^^^^^^^^^

--- a/source/docs/software/getting-started/options-for-programming.rst
+++ b/source/docs/software/getting-started/options-for-programming.rst
@@ -69,7 +69,6 @@ Advantages
 - Recommended if you're learning or have learned some programming, even better if you know a little Java.
 - Much greater flexibility than Blocks.
 - Much easier to integrate libraries like `FTC Dashboard`_, `FTCLib`_, and `Road Runner`_.
-- Can use plugins like `Road Runner`_.
 - Can use either a USB connection to the :term:`RC <Robot Controller>` phone, or a wireless connection to upload code.
 - Can debug in real-time
 - Many resources for Java, Android Studio, and IDEA


### PR DESCRIPTION
EasyOpenCV has since been integrated into the SDK, and OpenRC Turbo has been dead for a while.