### PR TITLE
license.rst: Use formatting from offical documentation

### DIFF
--- a/source/docs/appendix/license.rst
+++ b/source/docs/appendix/license.rst
@@ -28,8 +28,12 @@ No warranties are given. The license may not give you all of the permissions nec
 Legal Disclaimers
 -----------------
 
-*FIRST*\ |reg|, *FIRST*\ |reg| *Robotics Competition*, and *FIRST*\ |reg| *Tech Challenge*, are registered trademarks of FIRST\ |reg| (https://www.firstinspires.org) which is not overseeing, involved with, or responsible for this activity, product, or service.
+*FIRST*\ |reg|\ *, FIRST*\ |reg| *Robotics Competition, and FIRST*\ |reg| *Tech Challenge, are registered trademarks of FIRST*\ |reg| *\(*\ |firstinspires.org|_\ *) which is not overseeing, involved with, or responsible for this activity, product, or service.*
 
-*FIRST*\ |reg| **LEGO**\ |reg| *League* is a jointly held trademark of *FIRST*\ |reg| (https://www.firstinspires.org) and the **LEGO Group**, neither of which is overseeing, involved with, or responsible for this activity, product, or service.
+*FIRST*\ |reg| LEGO\ |reg| League is a jointly held trademark of *FIRST*\ |reg| *\(*\ |firstinspires.org|_\ *) and* the LEGO Group, *neither of which is overseeing, involved with, or responsible for this activity, product, or service.*
 
-**LEGO**\ |reg|, the **LEGO**\ |reg| logo, **MINDSTORMS**\ |reg|, the **MINDSTORMS**\ |reg| *NXT* logo, the *Minifigure*, and the *Brick* and *Knob* configurations are trademarks of the LEGO Group which is not overseeing, involved with, or responsible for this activity, product, or service.
+LEGO\ |reg|, *the* LEGO\ |reg| *logo*, MINDSTORMS\ |reg|, *the* MINDSTORMS\ |reg| *NXT logo, the Minifigure, and the Brick and Knob configurations are trademarks of* the LEGO Group *which is not overseeing, involved with, or responsible for this activity, product, or service.*
+
+.. _firstinspires.org: https://www.firstinspires.org
+
+.. |firstinspires.org| replace:: *www.firstinspires.org*


### PR DESCRIPTION
The formatting should match what is found in https://info.firstinspires.org/hubfs/web/about/policy/ip-policy-trademarks-copyrighted-materials-first-lego.pdf verbatim.  Companies and organizations care a lot about this stuff; we should probably follow what they say to use unless explicitly told otherwise.